### PR TITLE
Allow evaluating fitness not in parallel

### DIFF
--- a/examples/function_approximation.rs
+++ b/examples/function_approximation.rs
@@ -8,39 +8,39 @@ extern crate rusty_dashed;
 #[cfg(feature = "telemetry")]
 mod telemetry_helper;
 
-use rustneat::{Environment, Organism, Population, NeuralNetwork, NeatParams};
+use rustneat::{Environment, NeatParams, NeuralNetwork, Organism, Population};
 
 static mut BEST_FITNESS: f64 = 0.0;
 struct FunctionApproximation;
 
 impl Environment for FunctionApproximation {
-  fn test(&self, organism: &mut NeuralNetwork) -> f64 {
-      let nn = organism.make_network();
-      let mut output = vec![0f64];
-      let mut distance = 0f64;
+    fn test(&self, organism: &mut NeuralNetwork) -> f64 {
+        let nn = organism.make_network();
+        let mut output = vec![0f64];
+        let mut distance = 0f64;
 
-      let mut outputs = Vec::new();
+        let mut outputs = Vec::new();
 
-      for x in -10..11 {
-          nn.activate(vec![x as f64 / 10f64], &mut output);
-          distance += ((x as f64).powf(2f64) - (output[0] * 100f64)).abs();
-          outputs.push([x, (output[0] * 100f64) as i64]);
-      }
+        for x in -10..11 {
+            nn.activate(vec![x as f64 / 10f64], &mut output);
+            distance += ((x as f64).powf(2f64) - (output[0] * 100f64)).abs();
+            outputs.push([x, (output[0] * 100f64) as i64]);
+        }
 
-      let fitness = 100f64 / (1f64 + (distance / 1000.0));
-      unsafe {
+        let fitness = 100f64 / (1f64 + (distance / 1000.0));
+        unsafe {
             if fitness > BEST_FITNESS {
                 BEST_FITNESS = fitness;
-      #[cfg(feature = "telemetry")]
-      telemetry!("approximation1", 1.0, format!("{:?}", outputs));
+                #[cfg(feature = "telemetry")]
+                telemetry!("approximation1", 1.0, format!("{:?}", outputs));
             }
-      }
-      fitness
-  }
+        }
+        fitness
+    }
 }
 
 fn main() {
-    let p = NeatParams::optimized_for_xor3(1,1);
+    let p = NeatParams::optimized_for_xor3(1, 1);
     let mut population = Population::create_population(150);
     let mut environment = FunctionApproximation;
     let mut champion: Option<Organism> = None;
@@ -52,7 +52,11 @@ fn main() {
     std::thread::sleep(std::time::Duration::from_millis(2000));
 
     #[cfg(feature = "telemetry")]
-    telemetry!("approximation1", 1.0, format!("{:?}", (-10..11).map(|x| [x, x * x]).collect::<Vec<_>>()));
+    telemetry!(
+        "approximation1",
+        1.0,
+        format!("{:?}", (-10..11).map(|x| [x, x * x]).collect::<Vec<_>>())
+    );
 
     #[cfg(feature = "telemetry")]
     std::thread::sleep(std::time::Duration::from_millis(2000));

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,7 @@
 extern crate rand;
 extern crate rustneat;
 
-use rustneat::{Environment, Organism, Population, NeuralNetwork, NeatParams};
+use rustneat::{Environment, NeatParams, NeuralNetwork, Organism, Population};
 
 #[cfg(feature = "telemetry")]
 mod telemetry_helper;
@@ -49,7 +49,7 @@ fn main() {
     let mut i = 0;
     while champion.is_none() && i < MAX_ITERATIONS {
         i += 1;
-        population.evolve(&mut environment, &p);
+        population.evolve(&mut environment, &p,true);
         for organism in population.get_organisms() {
             if organism.fitness > best_fitness {
                 best_fitness = organism.fitness;
@@ -62,7 +62,9 @@ fn main() {
     }
     let best_organism = best_organism.unwrap();
     println!("Result: {}", best_fitness);
-    println!(" - {} neurons, {} connections",
-             best_organism.genome.n_neurons(),
-             best_organism.genome.n_connections());
+    println!(
+        " - {} neurons, {} connections",
+        best_organism.genome.n_neurons(),
+        best_organism.genome.n_connections()
+    );
 }

--- a/examples/telemetry_helper.rs
+++ b/examples/telemetry_helper.rs
@@ -8,7 +8,7 @@ extern crate rusty_dashed;
 use self::rusty_dashed::Dashboard;
 
 #[allow(dead_code)]
-pub fn main(){}
+pub fn main() {}
 
 #[cfg(feature = "telemetry")]
 pub fn enable_telemetry(query_string: &str, open: bool) {

--- a/src/bin/hyper_opt.rs
+++ b/src/bin/hyper_opt.rs
@@ -37,7 +37,7 @@ fn run(p: &NeatParams, n_gen: usize) -> f64 {
     let mut population = Population::create_population_from(start_genome, 200);
     let mut environment = XORClassification;
     for _ in 0..n_gen {
-        population.evolve(&mut environment, p);
+        population.evolve(&mut environment, p,true);
     }
 
     let mut best_fitness = 0.0;

--- a/src/bin/hyper_opt.rs
+++ b/src/bin/hyper_opt.rs
@@ -3,12 +3,12 @@ extern crate blackbox_derive;
 #[macro_use]
 extern crate slog;
 
-use blackbox_derive::make_optimizer;
 use blackbox::BlackboxInput;
+use blackbox_derive::make_optimizer;
 use slog::Logger;
 
-use rustneat::{Environment, Organism, Population, NeuralNetwork, NeatParams};
 use chrono::{Timelike, Utc};
+use rustneat::{Environment, NeatParams, NeuralNetwork, Organism, Population};
 
 struct XORClassification;
 
@@ -33,7 +33,6 @@ impl Environment for XORClassification {
 }
 
 fn run(p: &NeatParams, n_gen: usize) -> f64 {
-
     let start_genome = NeuralNetwork::with_neurons(3);
     let mut population = Population::create_population_from(start_genome, 200);
     let mut environment = XORClassification;
@@ -65,14 +64,14 @@ make_optimizer! {
         mutate_add_neuron_pr: f64 = 0.01..0.04,
         mutate_del_neuron_pr: f64 = 0.01..0.04,
 
-        // weight_init_mean: 0.0, 
-        weight_init_var: f64 = 0.5 .. 2.0, 
+        // weight_init_mean: 0.0,
+        weight_init_var: f64 = 0.5 .. 2.0,
         weight_mutate_var: f64 = 0.2 .. 2.0,
         weight_mutate_pr: f64 = 0.2 .. 0.8,
         weight_replace_pr: f64 = 0.01 .. 0.2,
 
-        // bias_init_mean: 0.0, 
-        bias_init_var: f64 = 0.5 .. 2.0, 
+        // bias_init_mean: 0.0,
+        bias_init_var: f64 = 0.5 .. 2.0,
         bias_mutate_var: f64 = 0.2 .. 2.0,
         bias_mutate_pr: f64 = 0.2 .. 0.8,
         bias_replace_pr: f64 = 0.01 .. 0.2,
@@ -103,13 +102,13 @@ make_optimizer! {
         include_weak_disjoint_gene,
 
         weight_init_mean: 0.0,
-        weight_init_var, 
+        weight_init_var,
         weight_mutate_var,
         weight_mutate_pr,
         weight_replace_pr,
 
         bias_init_mean: 0.0,
-        bias_init_var, 
+        bias_init_var,
         bias_mutate_var,
         bias_mutate_pr,
         bias_replace_pr,
@@ -124,13 +123,18 @@ make_optimizer! {
         .sum::<f64>() / N_POPULATIONS as f64;
     println!("Iteration... Score = {}", score);
     score
-    
+
 }
 
 fn main() {
     let log = slog::Logger::root(slog::Discard, o!());
     let now = Utc::now();
-    println!("Start: {:02}:{:02}:{:02}", now.hour(), now.minute(), now.second());
+    println!(
+        "Start: {:02}:{:02}:{:02}",
+        now.hour(),
+        now.minute(),
+        now.second()
+    );
 
     const N_ITER: usize = 2000;
     let config = Configuration::bayesian_search(12, N_ITER, log.clone());

--- a/src/bin/xor_performance.rs
+++ b/src/bin/xor_performance.rs
@@ -98,7 +98,7 @@ fn solve_time_perf(p: &NeatParams, n_exp: usize, n_gen: usize, population_size: 
         let mut champion: Option<Organism> = None;
         let mut i = 0;
         while champion.is_none() && i < n_gen {
-            population.evolve(&mut environment, &p);
+            population.evolve(&mut environment, &p,true);
             for organism in population.get_organisms() {
                 if organism.fitness > 15.7 {
                     champion = Some(organism.clone());
@@ -148,7 +148,7 @@ fn fixed_generations_perf(p: &NeatParams) {
         let mut environment = XORClassification;
 
         for i in 0..N_GEN {
-            population.evolve(&mut environment, &p);
+            population.evolve(&mut environment, &p,true);
 
             let best_organism = population.get_champion();
 

--- a/src/bin/xor_performance.rs
+++ b/src/bin/xor_performance.rs
@@ -1,11 +1,11 @@
 extern crate rand;
 extern crate rustneat;
 
-use rustneat::{Environment, Population, NeuralNetwork, NeatParams, Organism};
+use rustneat::{Environment, NeatParams, NeuralNetwork, Organism, Population};
 use std::io::Write;
 
-// This example measure average XOR performance, and should be useful to check that changes in the
-// algorithm doesn't break the algorithm
+// This example measure average XOR performance, and should be useful to check
+// that changes in the algorithm doesn't break the algorithm
 
 struct XORClassification;
 
@@ -31,52 +31,55 @@ impl Environment for XORClassification {
 
 fn main() {
     // let p = NeatParams {
-        // n_inputs: 2,
-        // n_outputs: 1,
+    // n_inputs: 2,
+    // n_outputs: 1,
 
-        // remove_after_n_generations: 18,
-        // species_elite: 2,
+    // remove_after_n_generations: 18,
+    // species_elite: 2,
 
-        // mutation_pr: 1.0,
-        // interspecie_mate_pr: 0.01,
-        // cull_fraction: 0.2,
+    // mutation_pr: 1.0,
+    // interspecie_mate_pr: 0.01,
+    // cull_fraction: 0.2,
 
-        // mutate_add_conn_pr: 0.5,
-        // mutate_del_conn_pr: 0.5,
-        // mutate_add_neuron_pr: 0.1,
-        // mutate_del_neuron_pr: 0.1,
+    // mutate_add_conn_pr: 0.5,
+    // mutate_del_conn_pr: 0.5,
+    // mutate_add_neuron_pr: 0.1,
+    // mutate_del_neuron_pr: 0.1,
 
-        // weight_init_mean: 0.0, 
-        // weight_init_var: 1.0, 
-        // weight_mutate_var: 0.5,
-        // weight_mutate_pr: 0.8,
-        // weight_replace_pr: 0.1,
+    // weight_init_mean: 0.0,
+    // weight_init_var: 1.0,
+    // weight_mutate_var: 0.5,
+    // weight_mutate_pr: 0.8,
+    // weight_replace_pr: 0.1,
 
-        // bias_init_mean: 0.0, 
-        // bias_init_var: 1.0, 
-        // bias_mutate_var: 0.5,
-        // bias_mutate_pr: 0.7,
-        // bias_replace_pr: 0.1,
+    // bias_init_mean: 0.0,
+    // bias_init_var: 1.0,
+    // bias_mutate_var: 0.5,
+    // bias_mutate_pr: 0.7,
+    // bias_replace_pr: 0.1,
 
-        // include_weak_disjoint_gene: 0.0,
+    // include_weak_disjoint_gene: 0.0,
 
-        // // other
-        // compatibility_threshold: 3.3,
-        // distance_weight_coef: 0.13,
-        // distance_disjoint_coef: 0.6,
+    // // other
+    // compatibility_threshold: 3.3,
+    // distance_weight_coef: 0.13,
+    // distance_disjoint_coef: 0.6,
     // };
     let p = NeatParams::optimized_for_xor3(2, 1);
 
-
     use chrono::{Timelike, Utc};
     let now = Utc::now();
-    println!("Start: {:02}:{:02}:{:02}", now.hour(), now.minute(), now.second());
+    println!(
+        "Start: {:02}:{:02}:{:02}",
+        now.hour(),
+        now.minute(),
+        now.second()
+    );
 
     solve_time_perf(&p, 40, 1000, 150);
     // fixed_generations_perf(&p);
-    
-    println!("\nExecution time: {}", (Utc::now() - now).num_seconds());
 
+    println!("\nExecution time: {}", (Utc::now() - now).num_seconds());
 }
 
 /// See how fast, on average, rustneat can solve XOR
@@ -86,7 +89,7 @@ fn solve_time_perf(p: &NeatParams, n_exp: usize, n_gen: usize, population_size: 
     let mut connections = Vec::new();
     let mut could_not_solve = 0;
     for exp in 0..n_exp {
-        print!("Experiment {}/{}\r", exp+1, n_exp);
+        print!("Experiment {}/{}\r", exp + 1, n_exp);
         std::io::stdout().flush().unwrap();
         let start_genome = NeuralNetwork::with_neurons(3);
         let mut population = Population::create_population_from(start_genome, population_size);
@@ -138,7 +141,7 @@ fn fixed_generations_perf(p: &NeatParams) {
     let mut neurons = Vec::new();
     let mut connections = Vec::new();
     for exp in 0..N_EXP {
-        print!("Experiment {}/{}\r", exp+1, N_EXP);
+        print!("Experiment {}/{}\r", exp + 1, N_EXP);
         std::io::stdout().flush().unwrap();
         let start_genome = NeuralNetwork::with_neurons(3);
         let mut population = Population::create_population_from(start_genome, 150);
@@ -149,8 +152,7 @@ fn fixed_generations_perf(p: &NeatParams) {
 
             let best_organism = population.get_champion();
 
-
-            if i == N_GEN-1 {
+            if i == N_GEN - 1 {
                 scores.push(best_organism.fitness);
                 neurons.push(best_organism.genome.n_neurons());
                 connections.push(best_organism.genome.n_connections());
@@ -174,6 +176,4 @@ fn fixed_generations_perf(p: &NeatParams) {
         let mean = connections.iter().sum::<usize>() as f64 / connections.len() as f64;
         println!("Connections:  {}", mean);
     }
-
-
 }

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -1,9 +1,10 @@
-use crate::{NeuralNetwork, NeatParams};
+use crate::{NeatParams, NeuralNetwork};
 
-/// Implementing `Genome` conceptually means that the implementor "has a genome", and the
-/// implementor can be called an "organism".
+/// Implementing `Genome` conceptually means that the implementor "has a
+/// genome", and the implementor can be called an "organism".
 pub trait Genome: Clone + Default + Send + std::fmt::Debug {
-    /// Returns a new organism which is a clone of `&self` apart from possible mutations
+    /// Returns a new organism which is a clone of `&self` apart from possible
+    /// mutations
     fn mutate(&mut self, innovation_id: &mut usize, p: &NeatParams);
 
     /// `fittest` is true if `other` is more fit.
@@ -12,7 +13,6 @@ pub trait Genome: Clone + Default + Send + std::fmt::Debug {
     /// TODO: how should it be implemented for e.g. a composed organism?
     fn distance(&self, other: &Self, p: &NeatParams) -> f64;
 
-
     /// Compare another Genome for species equality
     // TODO This should be impl Eq
     fn is_same_specie(&self, other: &Self, p: &NeatParams) -> bool {
@@ -20,8 +20,8 @@ pub trait Genome: Clone + Default + Send + std::fmt::Debug {
     }
 }
 
-/// Used in algorithm just to group an organism (genome) with its fitness, and also in the
-/// interface to get the fitness of organisms
+/// Used in algorithm just to group an organism (genome) with its fitness, and
+/// also in the interface to get the fitness of organisms
 #[derive(Default, Clone, Debug)]
 pub struct Organism<G = NeuralNetwork> {
     /// The genome of this organism
@@ -45,10 +45,11 @@ impl<G: Genome> Organism<G> {
     pub fn mate(&self, other: &Self, p: &NeatParams) -> Organism<G> {
         Organism::new(
             self.genome
-                .mate(&other.genome, self.fitness > other.fitness, p))
+                .mate(&other.genome, self.fitness > other.fitness, p),
+        )
     }
-    /// 
+    ///
     pub fn distance(&self, other: &Self, p: &NeatParams) -> f64 {
-        self.genome.distance(&other.genome,p )
+        self.genome.distance(&other.genome, p)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,17 @@
 #![deny(
-    missing_docs, trivial_casts, trivial_numeric_casts, unsafe_code, unused_import_braces,
+    missing_docs,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unused_import_braces,
     unused_qualifications
 )]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
-#![cfg_attr(feature = "clippy", deny(clippy, unicode_not_nfc, wrong_pub_self_convention))]
+#![cfg_attr(
+    feature = "clippy",
+    deny(clippy, unicode_not_nfc, wrong_pub_self_convention)
+)]
 #![cfg_attr(feature = "clippy", allow(use_debug, too_many_arguments))]
 
 //! Implementation of `NeuroEvolution` of Augmenting Topologies [NEAT]
@@ -23,22 +30,21 @@ extern crate serde_derive;
 #[cfg(feature = "telemetry")]
 extern crate serde_json;
 
-
-pub use self::genome::*;
 pub use self::environment::Environment;
+pub use self::genome::*;
+pub use self::nn::{ConnectionGene, NeuralNetwork, NeuronGene};
+pub use self::params::NeatParams;
 pub use self::population::Population;
 pub use self::specie::Specie;
-pub use self::nn::{NeuralNetwork, ConnectionGene, NeuronGene};
-pub use self::params::NeatParams;
 
-/// Contains the definition of the genome of neural networks, which is the basic building block of
-/// an organism (and in many cases, the only building block).
-pub mod nn;
 /// Trait to define test parameter
 mod environment;
 /// A collection of genes
 mod genome;
+/// Contains the definition of the genome of neural networks, which is the basic
+/// building block of an organism (and in many cases, the only building block).
+pub mod nn;
+mod params;
 /// A collection of species with champion
 mod population;
 mod specie;
-mod params;

--- a/src/nn/ctrnn.rs
+++ b/src/nn/ctrnn.rs
@@ -1,12 +1,13 @@
 use rulinalg::matrix::{BaseMatrix, BaseMatrixMut, Matrix};
 
-/// Continuous Time Recurrent Neural Network implementation, which the `NeuralNetwork` genome encodes for.
+/// Continuous Time Recurrent Neural Network implementation, which the
+/// `NeuralNetwork` genome encodes for.
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
 pub struct Ctrnn {
-    theta: Matrix<f64>, //bias
+    theta: Matrix<f64>, // bias
     delta_t_tau: Matrix<f64>,
-    wij: Matrix<f64>, //weights
+    wij: Matrix<f64>, // weights
     steps: usize,
 }
 
@@ -18,11 +19,11 @@ impl Ctrnn {
             theta: Ctrnn::vector_to_column_matrix(theta),
             wij: Ctrnn::vector_to_matrix(wij),
             delta_t_tau: tau.apply(&(|x| 1.0 / x)) * delta_t,
-            steps
+            steps,
         }
     }
-    /// Activate the neural network. The output is written to `output`, the amount depending on the
-    /// length of `output`.
+    /// Activate the neural network. The output is written to `output`, the
+    /// amount depending on the length of `output`.
     pub fn activate(&self, mut input: Vec<f64>, output: &mut [f64]) {
         let n_inputs = input.len();
         let n_neurons = self.theta.rows();
@@ -36,10 +37,11 @@ impl Ctrnn {
         let mut y = input.clone(); // TODO: correct? Or zero-vector?
         for _ in 0..self.steps {
             let activations = (&y + &self.theta).apply(&Ctrnn::sigmoid);
-            y = &y + self.delta_t_tau.elemul(
-                &((&self.wij * activations) - &y + &input)
-            );
-        };
+            y = &y
+                + self
+                    .delta_t_tau
+                    .elemul(&((&self.wij * activations) - &y + &input));
+        }
         let y = y.into_vec();
 
         if n_inputs < n_neurons {
@@ -94,6 +96,7 @@ mod tests {
     #[test]
     fn neural_network_activation_stability() {
         // TODO
-        // This test should just ensure that a stable neural network implementation doesn't change
+        // This test should just ensure that a stable neural network implementation
+        // doesn't change
     }
 }

--- a/src/nn/gene.rs
+++ b/src/nn/gene.rs
@@ -1,6 +1,5 @@
+use serde_derive::{Deserialize, Serialize};
 use std::hash::Hash;
-use serde_derive::{Serialize, Deserialize};
-
 
 // TODO make private - only needed internally I think
 ///
@@ -9,8 +8,8 @@ pub trait Gene: Copy {
     type Id: Hash + Eq + Clone + Copy;
     ///
     fn id(&self) -> Self::Id;
-    /// Some way to get the (compatibility) distance between two genes, used in calculating the
-    /// distance between genomes
+    /// Some way to get the (compatibility) distance between two genes, used in
+    /// calculating the distance between genomes
     fn distance(&self, other: &Self) -> f64;
     // TODO maybe add `fn mutate(&mut self, p: &Params)` here :o
 }
@@ -45,7 +44,6 @@ impl Gene for NeuronGene {
         (self.bias - other.bias).abs()
     }
 }
-
 
 /// Innovation id of a connection gene = (input neuron id, output neuron id)
 pub type ConnectionId = (usize, usize);

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,26 +1,32 @@
 use serde_derive::{Deserialize, Serialize};
 
-/// Contains all parameters for the NEAT algorithm. A reference to `NeatParams` will be passed around
-/// internally. Usually you only need to give it to `Population::evolve`.
+/// Contains all parameters for the NEAT algorithm. A reference to `NeatParams`
+/// will be passed around internally. Usually you only need to give it to
+/// `Population::evolve`.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct NeatParams {
-    /// Number of inputs to the neural network. Only used to ensure a certain amount of neurons.
+    /// Number of inputs to the neural network. Only used to ensure a certain
+    /// amount of neurons.
     pub n_inputs: usize,
-    /// Number of outputs to the neural network. Only used to ensure a certain amount of neurons.
+    /// Number of outputs to the neural network. Only used to ensure a certain
+    /// amount of neurons.
     pub n_outputs: usize,
     // In `Population`
-    /// Maximum number of generations without improvement in a species, before that species is
-    /// removed.
+    /// Maximum number of generations without improvement in a species, before
+    /// that species is removed.
     pub remove_after_n_generations: usize,
     /// Number of best species that cannot be removed due to stagnation
     pub species_elite: usize,
 
     // In `Specie`
-    /// The probability of just mutating (as opposed to mating), during selection
+    /// The probability of just mutating (as opposed to mating), during
+    /// selection
     pub mutation_pr: f64,
-    /// The probability that an organism mates with an organism outside of their species
+    /// The probability that an organism mates with an organism outside of their
+    /// species
     pub interspecie_mate_pr: f64,
-    /// The fraction of organisms to cull from a species before selection (worst-performing ones)
+    /// The fraction of organisms to cull from a species before selection
+    /// (worst-performing ones)
     pub cull_fraction: f64,
     // TODO: n_elites or elite_fraction
 
@@ -34,46 +40,49 @@ pub struct NeatParams {
     /// The probability of deleting a neuron during mutation
     pub mutate_del_neuron_pr: f64,
 
-
     /// The mean (normal distribution) of the weight of a new connection
-    pub weight_init_mean: f64, 
+    pub weight_init_mean: f64,
     /// The variance (normal distribution) of the weight of a new connection
-    pub weight_init_var: f64, 
-    /// The variance (normal distribution) of a mutation of the weight of an existing connection
+    pub weight_init_var: f64,
+    /// The variance (normal distribution) of a mutation of the weight of an
+    /// existing connection
     pub weight_mutate_var: f64,
-    /// The probability to perturb the weights of a connection (simulated for each connection
-    /// individually) when mutating
+    /// The probability to perturb the weights of a connection (simulated for
+    /// each connection individually) when mutating
     pub weight_mutate_pr: f64,
-    /// The probability to replace the weights of a connection (simulated for each connection
-    /// individually) when mutating
+    /// The probability to replace the weights of a connection (simulated for
+    /// each connection individually) when mutating
     pub weight_replace_pr: f64,
 
     /// The mean (normal distribution) of the bias of a new connection
-    pub bias_init_mean: f64, 
+    pub bias_init_mean: f64,
     /// The variance (normal distribution) of the bias of a new connection
-    pub bias_init_var: f64, 
-    /// The variance (normal distribution) of a mutation of the bias of an existing connection
+    pub bias_init_var: f64,
+    /// The variance (normal distribution) of a mutation of the bias of an
+    /// existing connection
     pub bias_mutate_var: f64,
-    /// The probability to perturb the biases of a connection (simulated for each connection
-    /// individually) when mutating
+    /// The probability to perturb the biases of a connection (simulated for
+    /// each connection individually) when mutating
     pub bias_mutate_pr: f64,
-    /// The probability to replace the biases of a connection (simulated for each connection
-    /// individually) when mutating
+    /// The probability to replace the biases of a connection (simulated for
+    /// each connection individually) when mutating
     pub bias_replace_pr: f64,
 
-    /// The probability, during mating, of including a gene that is disjoint or excess,
-    /// from the organisms that is least fit
+    /// The probability, during mating, of including a gene that is disjoint or
+    /// excess, from the organisms that is least fit
     pub include_weak_disjoint_gene: f64,
 
     // (TODO: tau and n_steps in `activate()`
 
     // Other
     /// Threshold for distance (compatibility) between organisms,
-    /// under which the organisms are considered 'compatible', i.e. belonging to the same species.
+    /// under which the organisms are considered 'compatible', i.e. belonging to
+    /// the same species.
     pub compatibility_threshold: f64,
     /// How much connection weights and node biases contribute to the distance.
     pub distance_weight_coef: f64,
-    /// How much disjoint/excess (not in common) connections and neurons contribute to the distance
+    /// How much disjoint/excess (not in common) connections and neurons
+    /// contribute to the distance
     pub distance_disjoint_coef: f64,
 }
 
@@ -96,18 +105,17 @@ impl NeatParams {
             mutate_add_neuron_pr: 0.1,
             mutate_del_neuron_pr: 0.1,
 
-            weight_init_mean: 0.0, 
-            weight_init_var: 1.0, 
+            weight_init_mean: 0.0,
+            weight_init_var: 1.0,
             weight_mutate_var: 0.5,
             weight_mutate_pr: 0.8,
             weight_replace_pr: 0.1,
 
-            bias_init_mean: 0.0, 
-            bias_init_var: 1.0, 
+            bias_init_mean: 0.0,
+            bias_init_var: 1.0,
             bias_mutate_var: 0.5,
             bias_mutate_pr: 0.7,
             bias_replace_pr: 0.1,
-
 
             include_weak_disjoint_gene: 0.2,
 
@@ -118,8 +126,6 @@ impl NeatParams {
         }
     }
 }
-
-
 
 impl NeatParams {
     // temporary
@@ -150,7 +156,7 @@ impl NeatParams {
             include_weak_disjoint_gene: 0.2922982738026929,
             compatibility_threshold: 3.0772944943236347,
             distance_weight_coef: 0.32272770736662426,
-            distance_disjoint_coef: 0.7457289806719729
+            distance_disjoint_coef: 0.7457289806719729,
         }
     }
 }

--- a/src/population.rs
+++ b/src/population.rs
@@ -300,7 +300,7 @@ mod tests {
         let p = NeatParams::default(0, 0);
         let mut population = Population::create_population(150);
         for _ in 0..150 {
-            population.evolve(&mut X, &p);
+            population.evolve(&mut X, &p,true);
         }
         assert!(population.size() == 150);
     }

--- a/src/population.rs
+++ b/src/population.rs
@@ -1,7 +1,7 @@
-use crate::{Genome, Organism, Environment, Specie, NeuralNetwork, NeatParams};
+use crate::{Environment, Genome, NeatParams, NeuralNetwork, Organism, Specie};
 use rayon::prelude::*;
 // use std::cmp::Ordering::*;
-use rand::distributions::{Uniform, Distribution};
+use rand::distributions::{Distribution, Uniform};
 use std::f64;
 
 #[cfg(feature = "telemetry")]
@@ -9,7 +9,6 @@ use rusty_dashed;
 
 #[cfg(feature = "telemetry")]
 use serde_json;
-
 
 /// Contains several species, and a way to evolve these to the next generation.
 #[derive(Debug)]
@@ -21,14 +20,14 @@ pub struct Population<G: Genome = NeuralNetwork> {
 
     /// The latest innovation id
     innovation_id: usize,
-    /// To give each species a unique id. Useful for for example visualizing or processing the
-    /// species.
+    /// To give each species a unique id. Useful for for example visualizing or
+    /// processing the species.
     species_id: usize,
 }
 
 impl<G: Genome> Population<G> {
-    /// Create a new population with `population_size` organisms. Each organism will have only a single unconnected
-    /// neuron.
+    /// Create a new population with `population_size` organisms. Each organism
+    /// will have only a single unconnected neuron.
     pub fn create_population(population_size: usize) -> Population<G> {
         Self::create_population_from(G::default(), population_size)
     }
@@ -67,17 +66,21 @@ impl<G: Genome> Population<G> {
     /// Get the best-performing organism of the entire population.
     /// Fitness is already calculated during the last call to `evolve()`
     pub fn get_champion(&self) -> Organism<G> {
-        self.get_organisms().fold(None,
-            |state: Option<&Organism<G>>, organism|
+        self.get_organisms()
+            .fold(None, |state: Option<&Organism<G>>, organism| {
                 Some(match state {
                     None => organism,
-                    Some(state) => if organism.fitness > state.fitness {
-                        organism
-                    } else {
-                        state
+                    Some(state) => {
+                        if organism.fitness > state.fitness {
+                            organism
+                        } else {
+                            state
+                        }
                     }
                 })
-        ).unwrap().clone()
+            })
+            .unwrap()
+            .clone()
     }
     /// How many generations have passed without improvement in peak fitness
     pub fn generations_without_improvements(&self) -> usize {
@@ -86,12 +89,14 @@ impl<G: Genome> Population<G> {
 
     /// Evolve to the next generation. This includes, in order:
     /// * Collecting all organisms and dividing them into (new) species
-    /// * Creating a number of offsprings in each species depending on that species' average
+    /// * Creating a number of offsprings in each species depending on that
+    ///   species' average
     /// fitness
     /// * Evaluating the fitness of all organisms
     ///
-    /// Because of the last step, organisms will always have an up-to-date fitness value.
-    pub fn evolve(&mut self, env: &mut Environment<G>, p: &NeatParams) {
+    /// Because of the last step, organisms will always have an up-to-date
+    /// fitness value.
+    pub fn evolve(&mut self, env: &mut Environment<G>, p: &NeatParams, in_parallel: bool) {
         // Collect all organisms
         let organisms = self.get_organisms().cloned().collect::<Vec<_>>();
 
@@ -101,8 +106,11 @@ impl<G: Genome> Population<G> {
         // Give each species a number of offsprings related to that species'
         // average fitness
 
-        // Gather the average shared fitness, and the calculated number of offsprings, per species
-        let species_fitness = self.species.iter()
+        // Gather the average shared fitness, and the calculated number of offsprings,
+        // per species
+        let species_fitness = self
+            .species
+            .iter()
             .map(|species| species.average_fitness())
             .collect::<Vec<_>>();
 
@@ -120,41 +128,63 @@ impl<G: Genome> Population<G> {
         let max_fitness = species_fitness.iter().cloned().fold(f64::NAN, f64::max);
         let min_fitness = species_fitness.iter().cloned().fold(f64::NAN, f64::min);
         let fitness_range = f64::max(1.0, max_fitness - min_fitness);
-        let adjusted_fitness = species_fitness.iter()
-            .map(|fitness| fitness - min_fitness + fitness_range*0.2).collect::<Vec<_>>();
+        let adjusted_fitness = species_fitness
+            .iter()
+            .map(|fitness| fitness - min_fitness + fitness_range * 0.2)
+            .collect::<Vec<_>>();
         let total_adjusted_fitness = adjusted_fitness.iter().sum::<f64>();
 
-        let n_offspring: Vec<_> = 
-            Self::partition(
-                organisms.len(),
-                &adjusted_fitness.iter().map(|x| x/total_adjusted_fitness).collect::<Vec<_>>(),
-                elite_species);
+        let n_offspring: Vec<_> = Self::partition(
+            organisms.len(),
+            &adjusted_fitness
+                .iter()
+                .map(|x| x / total_adjusted_fitness)
+                .collect::<Vec<_>>(),
+            elite_species,
+        );
 
         for (species, n_offspring) in self.species.iter_mut().zip(n_offspring) {
             species.generate_offspring(n_offspring, &organisms, &mut self.innovation_id, p);
         }
 
-        // Evaluate the fitness of all organisms, in parallel
-        self.species.par_iter_mut()
-            .for_each(|species| species.organisms.par_iter_mut()
-                .for_each(|organism| {
+        if in_parallel {
+            // Evaluate the fitness of all organisms, in parallel
+            self.species.par_iter_mut().for_each(|species| {
+                species.organisms.par_iter_mut().for_each(|organism| {
                     organism.fitness = env.test(&mut organism.genome);
                     if organism.fitness < 0.0 {
                         eprintln!("Fitness {} < 0.0", organism.fitness);
                         std::process::exit(1);
                     }
-                }))
+                })
+            })
+        } else {
+            // Evaluate the fitness of all organisms
+            self.species.iter_mut().for_each(|species| {
+                species.organisms.iter_mut().for_each(|organism| {
+                    organism.fitness = env.test(&mut organism.genome);
+                    if organism.fitness < 0.0 {
+                        eprintln!("Fitness {} < 0.0", organism.fitness);
+                        std::process::exit(1);
+                    }
+                })
+            })
+        }
     }
-    
+
     // fn determine_new_species_sizes()
 
-    // Helper of `evolve`. Partition `total` into partitions with size given by `fractions`.
-    // We need this logic to ensure that the total stays the same after partitioning.
-    // `elite` is the index of a partition that will be ensured one spot
+    // Helper of `evolve`. Partition `total` into partitions with size given by
+    // `fractions`. We need this logic to ensure that the total stays the same
+    // after partitioning. `elite` is the index of a partition that will be
+    // ensured one spot
     fn partition(total: usize, fractions: &[f64], elite: usize) -> Vec<usize> {
         assert!(fractions.len() > 0);
         let mut rng = rand::thread_rng();
-        let mut partitions: Vec<usize> = fractions.iter().map(|x| ((total as f64 * x) as usize)).collect();
+        let mut partitions: Vec<usize> = fractions
+            .iter()
+            .map(|x| ((total as f64 * x) as usize))
+            .collect();
         let mut sum: usize = partitions.iter().sum();
         let range = Uniform::from(0..partitions.len());
         // println!("Fraction: {:?}", fractions);
@@ -180,7 +210,6 @@ impl<G: Genome> Population<G> {
         partitions
     }
 
-
     /// Helper of `evolve`
     fn speciate(&mut self, organisms: &[Organism<G>], p: &NeatParams) {
         for s in &mut self.species {
@@ -191,12 +220,17 @@ impl<G: Genome> Population<G> {
             }
         }
         for organism in organisms {
-            match self.species.iter_mut().find(|specie| specie.match_genome(&organism.genome, p)) {
+            match self
+                .species
+                .iter_mut()
+                .find(|specie| specie.match_genome(&organism.genome, p))
+            {
                 Some(specie) => {
                     specie.organisms.push(organism.clone());
                 }
                 None => {
-                    self.species.push(Specie::new(organism.clone(), self.species_id));
+                    self.species
+                        .push(Specie::new(organism.clone(), self.species_id));
                     self.species_id += 1;
                 }
             }
@@ -204,26 +238,35 @@ impl<G: Genome> Population<G> {
         self.species.retain(|s| s.organisms.len() > 0);
 
         // Update champion
-        self.species.iter_mut().for_each(|specie| specie.update_champion());
+        self.species
+            .iter_mut()
+            .for_each(|specie| specie.update_champion());
         // Sort by descending fitness
-        self.species.sort_by(|a, b| b.champion_fitness().partial_cmp(&a.champion_fitness()).unwrap());
+        self.species.sort_by(|a, b| {
+            b.champion_fitness()
+                .partial_cmp(&a.champion_fitness())
+                .unwrap()
+        });
         // Fitness above which a species will not be removed.
-        let safe_fitness = self.species[usize::min(p.species_elite-1, self.species.len()-1)].champion_fitness();
+        let safe_fitness = self.species[usize::min(p.species_elite - 1, self.species.len() - 1)]
+            .champion_fitness();
         // Kill species that haven't improved in a awhile
-        self.species.retain(|s| (s.age - s.age_last_improvement < p.remove_after_n_generations
-                                || s.champion_fitness() >= safe_fitness));
+        self.species.retain(|s| {
+            (s.age - s.age_last_improvement < p.remove_after_n_generations
+                || s.champion_fitness() >= safe_fitness)
+        });
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{Organism, Specie, NeuralNetwork, Population, Environment, NeatParams};
+    use crate::{Environment, NeatParams, NeuralNetwork, Organism, Population, Specie};
 
     #[test]
     fn population_should_be_able_to_speciate_genomes() {
         let p = NeatParams {
             compatibility_threshold: 0.0,
-            ..NeatParams::default(1,1)
+            ..NeatParams::default(1, 1)
         };
         let mut genome1 = NeuralNetwork::with_neurons(2);
         genome1.add_connection(0, 0, 1.0);
@@ -249,10 +292,12 @@ mod tests {
     fn after_population_evolve_population_should_be_the_same() {
         struct X;
         impl Environment<NeuralNetwork> for X {
-            fn test(&self, _organism: &mut NeuralNetwork) -> f64 { 0.0 }
+            fn test(&self, _organism: &mut NeuralNetwork) -> f64 {
+                0.0
+            }
         }
 
-        let p = NeatParams::default(0,0);
+        let p = NeatParams::default(0, 0);
         let mut population = Population::create_population(150);
         for _ in 0..150 {
             population.evolve(&mut X, &p);

--- a/src/specie.rs
+++ b/src/specie.rs
@@ -1,6 +1,9 @@
-use crate::{Genome, Organism, NeatParams};
+use crate::{Genome, NeatParams, Organism};
 use conv::prelude::*;
-use rand::{self, distributions::{Distribution, Uniform}};
+use rand::{
+    self,
+    distributions::{Distribution, Uniform},
+};
 
 /// A species (several organisms) and associated fitnesses
 #[derive(Debug, Clone)]
@@ -14,14 +17,14 @@ pub struct Specie<G: Genome> {
     pub age: usize,
     /// The age of the species at the last improvement
     pub age_last_improvement: usize,
-    
+
     /// All orgnamisms in this species
     pub organisms: Vec<Organism<G>>,
 }
 
-
 impl<G: Genome> Specie<G> {
-    /// Create a new species from a representative Organism. Adds this organism as the only member.
+    /// Create a new species from a representative Organism. Adds this organism
+    /// as the only member.
     pub fn new(genome: Organism<G>, id: usize) -> Specie<G> {
         Specie {
             id,
@@ -38,32 +41,45 @@ impl<G: Genome> Specie<G> {
     }
     ///
     pub fn get_champion(&self) -> Organism<G> {
-        self.organisms.iter().fold((std::f64::NEG_INFINITY, None), |state, organism| {
-                    if organism.fitness > state.0 {
-                        (organism.fitness, Some(organism))
-                    } else {
-                        state
-                    }
-        }).1.unwrap().clone()
+        self.organisms
+            .iter()
+            .fold((std::f64::NEG_INFINITY, None), |state, organism| {
+                if organism.fitness > state.0 {
+                    (organism.fitness, Some(organism))
+                } else {
+                    state
+                }
+            })
+            .1
+            .unwrap()
+            .clone()
     }
-    /// Get the best fitness of this species. Stores the value internally, and uses it in
-    /// subsequent calls to the function
+    /// Get the best fitness of this species. Stores the value internally, and
+    /// uses it in subsequent calls to the function
     pub fn champion_fitness(&self) -> f64 {
         match self.champion {
             Some(ref champion) => champion.fitness,
             None => panic!("Calling Specie::champion_fitness requires that you first call calculate_champion_fitness!"),
         }
     }
-    /// Calculate fitness of champion and store it internally, to be retrieved by `champion_fitness`
+    /// Calculate fitness of champion and store it internally, to be retrieved
+    /// by `champion_fitness`
     pub fn update_champion(&mut self) {
         assert!(self.organisms.len() > 0);
         let old_fitness = self.champion.as_ref().map(|x| x.fitness);
-        self.champion = Some(self.organisms.iter().fold((std::f64::NEG_INFINITY, None), |state, organism| {
+        self.champion = Some(
+            self.organisms
+                .iter()
+                .fold((std::f64::NEG_INFINITY, None), |state, organism| {
                     if organism.fitness > state.0 {
                         (organism.fitness, Some(organism.clone()))
                     } else {
                         state
-                    }}).1.unwrap());
+                    }
+                })
+                .1
+                .unwrap(),
+        );
         if let Some(old_fitness) = old_fitness {
             if self.champion.as_ref().unwrap().fitness > old_fitness {
                 self.age_last_improvement = self.age;
@@ -77,19 +93,21 @@ impl<G: Genome> Specie<G> {
             return 0.0;
         }
 
-        let avg_fitness = self.organisms.iter().map(|o| o.fitness)
-            .sum::<f64>() / n_organisms;
+        let avg_fitness = self.organisms.iter().map(|o| o.fitness).sum::<f64>() / n_organisms;
         avg_fitness
     }
 
-
-    /// Generate the next generation of genomes, which will replace the old within this species.
-    /// `champion_fitness`: the fitness of the population-wide champion. The reason for this
-    /// parameter is that the species should see if it is the best-performing one.
-    pub fn generate_offspring(&mut self, n_offspring: usize,
-                                         population_offspring: &[Organism<G>],
-                                         innovation_id: &mut usize,
-                                         p: &NeatParams) {
+    /// Generate the next generation of genomes, which will replace the old
+    /// within this species. `champion_fitness`: the fitness of the
+    /// population-wide champion. The reason for this parameter is that the
+    /// species should see if it is the best-performing one.
+    pub fn generate_offspring(
+        &mut self,
+        n_offspring: usize,
+        population_offspring: &[Organism<G>],
+        innovation_id: &mut usize,
+        p: &NeatParams,
+    ) {
         self.age += 1;
         if n_offspring == 0 {
             self.organisms = Vec::new();
@@ -97,39 +115,38 @@ impl<G: Genome> Specie<G> {
         }
         let mut rng = rand::thread_rng();
 
-        self.organisms.sort_by(|a, b| a.fitness.partial_cmp(&b.fitness).unwrap());
+        self.organisms
+            .sort_by(|a, b| a.fitness.partial_cmp(&b.fitness).unwrap());
 
-        // Organisms are split into 3 parts: Those that are culled, those that are guaranteed
-        // offspring through elitism, and the rest which are amenable to random selection.
-        // NOTE: For now, we always have n_elite = 2 or 0.
+        // Organisms are split into 3 parts: Those that are culled, those that are
+        // guaranteed offspring through elitism, and the rest which are amenable
+        // to random selection. NOTE: For now, we always have n_elite = 2 or 0.
 
-        // let n_elite = std::cmp::min(n_offspring, (self.organisms.len() as f64 * ELITE_FRACTION) as usize);
-        // let n_elite = std::cmp::max(1, n_elite);
-        let n_elite = if self.organisms.len() > 5 {
-            1
-        } else {
-            1
-        };
+        // let n_elite = std::cmp::min(n_offspring, (self.organisms.len() as f64 *
+        // ELITE_FRACTION) as usize); let n_elite = std::cmp::max(1, n_elite);
+        let n_elite = if self.organisms.len() > 5 { 1 } else { 1 };
         let first_elite = self.organisms.len() - n_elite;
 
         let n_random = n_offspring - n_elite;
 
-        let n_to_cull = std::cmp::min(first_elite,
-                                      (self.organisms.len() as f64 * p.cull_fraction) as usize);
+        let n_to_cull = std::cmp::min(
+            first_elite,
+            (self.organisms.len() as f64 * p.cull_fraction) as usize,
+        );
 
-        // println!("n_offspring={}, n_offspring={}, n_elite={}, first_elite={}, n_random={}, n_to_cull={}",
-                 // n_offspring, self.organisms.len(), n_elite, first_elite, n_random, n_to_cull);
+        // println!("n_offspring={}, n_offspring={}, n_elite={}, first_elite={},
+        // n_random={}, n_to_cull={}", n_offspring, self.organisms.len(),
+        // n_elite, first_elite, n_random, n_to_cull);
         let range = Uniform::from(n_to_cull..self.organisms.len());
-        let offspring: Vec<Organism<G>> =
-            Iterator::chain(
-                // mate n_random random organisms
-                range.sample_iter(&mut rng).take(n_random)
-                    .map(|i| self.create_child(&self.organisms[i], population_offspring, innovation_id, p)),
-                // copy elite organisms
-                (first_elite..self.organisms.len())
-                    .map(|i| self.organisms[i].clone())
-            )
-            .collect();
+        let offspring: Vec<Organism<G>> = Iterator::chain(
+            // mate n_random random organisms
+            range.sample_iter(&mut rng).take(n_random).map(|i| {
+                self.create_child(&self.organisms[i], population_offspring, innovation_id, p)
+            }),
+            // copy elite organisms
+            (first_elite..self.organisms.len()).map(|i| self.organisms[i].clone()),
+        )
+        .collect();
 
         self.organisms = offspring;
     }
@@ -144,8 +161,13 @@ impl<G: Genome> Specie<G> {
     }
 
     /// Create a new child by mutating and existing one or mating two genomes.
-    fn create_child(&self, organism: &Organism<G>, population_organisms: &[Organism<G>],
-                    innovation_id: &mut usize, p: &NeatParams) -> Organism<G> {
+    fn create_child(
+        &self,
+        organism: &Organism<G>,
+        population_organisms: &[Organism<G>],
+        innovation_id: &mut usize,
+        p: &NeatParams,
+    ) -> Organism<G> {
         let mut child = self.create_child_by_mate(organism, population_organisms, p);
 
         if rand::random::<f64>() < p.mutation_pr {
@@ -154,7 +176,12 @@ impl<G: Genome> Specie<G> {
         child
     }
 
-    fn create_child_by_mate(&self, organism: &Organism<G>, population_organisms: &[Organism<G>], p: &NeatParams) -> Organism<G> {
+    fn create_child_by_mate(
+        &self,
+        organism: &Organism<G>,
+        population_organisms: &[Organism<G>],
+        p: &NeatParams,
+    ) -> Organism<G> {
         let mut rng = rand::thread_rng();
         if rand::random::<f64>() > p.interspecie_mate_pr {
             let selected_mate = Uniform::from(0..self.organisms.len()).sample(&mut rng);
@@ -181,7 +208,7 @@ mod tests {
 
         let mut organism3 = Organism::new(NeuralNetwork::default());
         organism3.fitness = 20.0;
-        
+
         let mut specie = Specie::new(Organism::default(), 0);
         specie.organisms = vec![organism1, organism2, organism3];
 

--- a/tests/rustneat_tests.rs
+++ b/tests/rustneat_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use rustneat::{Environment, Organism, Population, NeuralNetwork, NeatParams};
+    use rustneat::{Environment, NeatParams, NeuralNetwork, Organism, Population};
 
     struct X;
 
@@ -15,14 +15,18 @@ mod test {
     impl Environment for XORClassification {
         fn test(&self, organism: &mut NeuralNetwork) -> f64 {
             let nn = organism.make_network();
-            let target_inputs = vec![vec![0.0, 0.0], vec![0.0, 1.0], vec![1.0, 0.0], vec![1.0, 1.0]];
+            let target_inputs = vec![
+                vec![0.0, 0.0],
+                vec![0.0, 1.0],
+                vec![1.0, 0.0],
+                vec![1.0, 1.0],
+            ];
             let target_outputs = vec![0.0, 1.0, 1.0, 0.0];
             let mut output = vec![0.0];
             let mut distance: f64 = 0.0;
             for (i, o) in target_inputs.iter().zip(target_outputs) {
                 nn.activate(i.clone(), &mut output);
                 distance += (o - output[0]).powi(2);
-
             }
             16.0 / (1.0 + distance)
         }
@@ -39,10 +43,10 @@ mod test {
         let p = NeatParams {
             mutation_pr: 1.0, // because mutation ensures we have connections
             mutate_del_conn_pr: 0.0,
-            ..NeatParams::default(1,1)
+            ..NeatParams::default(1, 1)
         };
         let mut population = Population::create_population(2);
-        population.evolve(&mut X, &p);
+        population.evolve(&mut X, &p,true);
         let genome = &population.get_organisms().next().unwrap().genome;
         assert_eq!(genome.connections.len(), 1);
     }
@@ -50,7 +54,7 @@ mod test {
     #[test]
     fn population_can_be_tested_on_environment() {
         let mut population = Population::create_population(10);
-        population.evolve(&mut X, &NeatParams::default(0,0));
+        population.evolve(&mut X, &NeatParams::default(0, 0),true);
         assert_eq!(population.get_organisms().next().unwrap().fitness, 0.1234);
     }
 
@@ -64,7 +68,7 @@ mod test {
         let mut champion: Option<Organism> = None;
         let mut i = 0;
         while champion.is_none() && i < MAX_GENERATIONS {
-            population.evolve(&mut environment, &p);
+            population.evolve(&mut environment, &p,true);
             for organism in population.get_organisms() {
                 // Test whether there is any organism that solves the problem
                 let mut output = vec![0.0; 4];
@@ -73,26 +77,28 @@ mod test {
                 nn.activate(vec![0.0, 1.0], &mut output[1..2]);
                 nn.activate(vec![1.0, 0.0], &mut output[2..3]);
                 nn.activate(vec![1.0, 1.0], &mut output[3..]);
-                if output[0].abs() < 0.1 && (1.0 - output[1]).abs() < 0.1 && (1.0 - output[2]).abs() < 0.1 && output[3].abs() < 0.1 {
+                if output[0].abs() < 0.1
+                    && (1.0 - output[1]).abs() < 0.1
+                    && (1.0 - output[2]).abs() < 0.1
+                    && output[3].abs() < 0.1
+                {
                     champion = Some(organism.clone());
                 }
             }
             i += 1;
         }
         println!("Solved in {} generations", i);
-
-
     }
 
     #[test]
     fn xor_can_only_improve() {
         const MAX_GENERATIONS: usize = 200;
-        let p = NeatParams::default(2,1);
+        let p = NeatParams::default(2, 1);
         let mut population = Population::create_population(150);
         let mut environment = XORClassification;
         let mut best_fitness = std::f64::MIN;
         for _ in 0..MAX_GENERATIONS {
-            population.evolve(&mut environment, &p);
+            population.evolve(&mut environment, &p,true);
 
             let mut best_fitness_in_gen = std::f64::MIN;
             for organism in population.get_organisms() {


### PR DESCRIPTION
This PR should allow evaluating fitness, not in parallel:
```rust
...
population.evolve(&mut environment, &p, /* evaluate in parallel */ true);
...
```