### PR TITLE
specie: Use saturating sub when deciding n_random

### DIFF
--- a/src/specie.rs
+++ b/src/specie.rs
@@ -126,7 +126,7 @@ impl<G: Genome> Specie<G> {
         let n_elite = if self.organisms.len() > 5 { 2 } else { 1 };
         let first_elite = self.organisms.len() - n_elite;
 
-        let n_random = n_offspring - n_elite;
+        let n_random = n_offspring.saturating_sub(n_elite);
 
         let n_to_cull = std::cmp::min(
             first_elite,


### PR DESCRIPTION
May underflow and cause allocation errors later when we collect the
organisms into a vector.